### PR TITLE
#17 ログイン失敗時にエラーメッセージを表示するように修正

### DIFF
--- a/front/src/components/Login.vue
+++ b/front/src/components/Login.vue
@@ -114,10 +114,15 @@ const Login = {
             400: "メールアドレスまたはパスワードが正しくありません。",
             500: "サーバー内部でエラーが発生しました。しばらくしてからアクセスしてください。"
           };
-          this.error_message = error_messages[error.response.status];
-          this.alert = true;
-
           console.log(error);
+          if (error.response) {
+            this.error_message = error_messages[error.response.status];
+            this.alert = true;
+          } else {
+            this.error_message =
+              "サーバーにアクセスできませんでした。インターネット接続を確認し、管理者へお問い合わせください。";
+            this.alert = true;
+          }
         });
     },
     clear() {


### PR DESCRIPTION
## 表示するエラー一覧
- APIサーバーが立ち上がっていない場合
  ![image](https://user-images.githubusercontent.com/40418321/77821839-9d523200-7130-11ea-8fe0-0d32cf620334.png)

- アクセスできたけどエラーが発生した場合
  ![image](https://user-images.githubusercontent.com/40418321/77821856-bc50c400-7130-11ea-96b2-ca8b765f5e42.png)

- パスワードが間違っている場合
  ![image](https://user-images.githubusercontent.com/40418321/77821801-4cdad480-7130-11ea-8523-832cf10b8def.png)
